### PR TITLE
use amlwwalker qml package in genqrc

### DIFF
--- a/cmd/genqrc/main.go
+++ b/cmd/genqrc/main.go
@@ -166,7 +166,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/SjB/qml"
+	"github.com/amlwwalker/qml"
 )
 
 func init() {


### PR DESCRIPTION
The code generated by genqrc needs to match the QML imports used in the rest of the app. If the coder is using your fork, then the generated code needs to reference your fork.